### PR TITLE
Sync profile README with homepage and refresh News

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,68 @@
+## Hi there 👋
 
-<h1 align="center">
-AcadHomepage
-</h1>
+<!--
+🌟🌟 **I will be in Rio de Janeiro, Brazil for [ICSE 2026](https://conf.researchr.org/home/icse-2026) next April—looking forward to meeting many of you there!** 🤗🤗
+-->
 
-<div align="center">
+🔭 I am a first-year PhD student in the Department of Computer Science at [**University College London (UCL)**](https://www.ucl.ac.uk/), co-supervised by [**Prof. Federica Sarro**](http://www0.cs.ucl.ac.uk/staff/F.Sarro/) and [**Dr. He Ye**](https://heye.me/).
+Previously, I completed my master's degree at the School of Computer Science and Technology, [**Huazhong University of Science and Technology (HUST)**](https://www.hust.edu.cn), advised by [**Prof. Yao Wan**](http://wanyao.me).
+My academic journey has also been enriched by collaborations with [**Prof. Lingming Zhang**](https://lingming.cs.illinois.edu/) at UIUC and [**Prof. Hongyu Zhang**](https://sites.google.com/site/hongyujohn/) at Chongqing University.
 
-[![](https://img.shields.io/github/stars/RayeRen/acad-homepage.github.io)](https://github.com/RayeRen/acad-homepage.github.io)
-[![](https://img.shields.io/github/forks/RayeRen/acad-homepage.github.io)](https://github.com/RayeRen/acad-homepage.github.io)
-[![](https://img.shields.io/github/issues/RayeRen/acad-homepage.github.io)](https://github.com/RayeRen/acad-homepage.github.io)
-[![](https://img.shields.io/github/license/RayeRen/acad-homepage.github.io)](https://github.com/RayeRen/acad-homepage.github.io/blob/main/LICENSE)  | [中文文档](./docs/README-zh.md) 
-</div>
+> ✨ My research interests lie at the intersection of software engineering and artificial intelligence, with an emphasis on **safe and reliable coding agents** for real-world software engineering workflows.
 
-<p align="center">A Modern and Responsive Academic Personal Homepage</p>
+😄 I am always eager to connect and collaborate, whether you share my interests or bring a different perspective from another field. If you'd like to discuss research, exchange ideas, or just say hi, feel free to reach out at [zhaoyang.chu.25@ucl.ac.uk](mailto:zhaoyang.chu.25@ucl.ac.uk) or [zychu418@gmail.com](mailto:zychu418@gmail.com).
 
-<p align="center">
-    <br>
-    <img src="docs/screenshot.png" width="100%"/>
-    <br>
-</p>
+### 💻 Homepages
 
-Some examples:
-- [Demo Page](https://rayeren.github.io/acad-homepage.github.io/)
-- [Personal Homepage of the author](https://rayeren.github.io/)
+- Personal Page: https://zhaoyang-chu.github.io (updated recently🔥)
+- Twitter: https://twitter.com/zhaoyang_c68411
+- LinkedIn: https://www.linkedin.com/in/zhaoyang-chu-ab3536306
+- Google Scholar: https://scholar.google.com/citations?user=HYu3DyEAAAAJ
 
-## Key Features
-- **Automatically update google scholar citations**: using the google scholar crawler and github action, this REPO can update the author citations and publication citations automatically.
-- **Support Google analytics**: you can trace the traffics of your homepage by easy configuration.
-- **Responsive**: this homepage automatically adjust for different screen sizes and viewports.
-- **Beautiful and Simple Design**: this homepage is beautiful and simple, which is very suitable for academic personal homepage.
-- **SEO**: search Engine Optimization (SEO) helps search engines find the information you publish on your homepage easily, then rank it against similar websites.
+<!--
+- Blog: https://blog.csdn.net/qq_44009891?spm=1000.2115.3001.5343
+-->
 
-## Quick Start
+<!--
+### 🔥 News
 
-1. Fork this REPO and rename to `USERNAME.github.io`, where `USERNAME` is your github USERNAME.
-1. Configure the google scholar citation crawler:
-    1. Find your google scholar ID in the url of your google scholar page (e.g., https://scholar.google.com/citations?user=SCHOLAR_ID), where `SCHOLAR_ID` is your google scholar ID.
-    1. Set GOOGLE_SCHOLAR_ID variable to your google scholar ID in `Settings -> Secrets -> Actions -> New repository secret` of the REPO website with `name=GOOGLE_SCHOLAR_ID` and `value=SCHOLAR_ID`.
-    1. Click the `Action` of the REPO website and enable the workflows by clicking *"I understand my workflows, go ahead and enable them"*. This github action will generate google scholar citation stats data `gs_data.json` in `google-scholar-stats` branch of your REPO. When you update your main branch, this action will be triggered. This action will also be trigger 08:00 UTC everyday.
-1. Generate favicon using [favicon-generator](https://redketchup.io/favicon-generator) and download all generated files to `REPO/images`.
-1. Modify the configuration of your homepage `_config.yml`:
-    1. `title`: the title of your homepage
-    1. `description`: the description of your homepage
-    1. `repository`: USER_NAME/REPO_NAME  
-    1. `google_analytics_id` (optional): google analytics ID
-    1. SEO Related keys (optional): get these keys from search engine consoles (e.g. Google, Bing and Baidu) and paste here.
-    1. `author`: the author information of this homepage, including some other websites, emails, city and univeristy.
-    1. More configuration details are described in the comments.
-1. Add your homepage content in `_pages/about.md`.
-    1. You can use html+markdown syntax just same as jekyll.
-    1. You can use a `<span>` tag with class `show_paper_citations` and attribute `data` to display the citations of your paper. Set the data to the google scholar paper ID. For
-        ```html
-        <span class='show_paper_citations' data='DhtAFkwAAAAJ:ALROH1vI_8AC'></span>
-        ``` 
-        > Q: How to get the google scholar paper ID?   
-        > A: Enter your google scholar homepage and click the paper name. Then you can see the paper ID from `citation_for_view=XXXX`, where `XXXX` is the required paper ID.
-1. Your page will be published at `https://USERNAME.github.io`.
+- *2025.06*: &nbsp;🎙️ TerminalWorld was featured on [**Last Week in AI**](https://lastweekin.ai/p/lwiai-podcast-246-gemini-35-omni) (ep. #246), a newsletter and podcast with 181k+ listeners.
+- *2025.05*: &nbsp;🤗 TerminalWorld dataset exceeded **5,000 downloads** on HuggingFace!
+- *2026.04*: &nbsp;🎉 Our two post-training papers on *code execution reasoning* and *structure-aware code understanding* were accepted to **ACL 2026**.
+- *2026.03*: &nbsp;🎉 Our paper on *LLM hallucination mitigation in code summarization* was accepted to **FSE 2026**.
+- *2025.08*: &nbsp;🎉 Our work on *efficient reasoning for R1-style LLMs* was accepted to **EMNLP 2025**.
+- *2025.07*: &nbsp;🎉 Our work on *LLM-as-a-Judge for code summarization* was accepted by **IEEE Transactions on Software Engineering**.
+- *2025.06*: &nbsp;🎉 Our paper on *machine unlearning for code LLMs* was accepted to **ICSE 2026**.
+- *2025.05*: &nbsp;🎉 Our research on *dynamic code knowledge synchronization for LLMs* was accepted to **ICML 2025**.
+- *2025.03*: &nbsp;🎉 Our SANER 2025 paper received the **IEEE TCSE Distinguished Paper Award🏆**!
+- *2025.01*: &nbsp;🎉 Our work on *test generation benchmark for LLMs* was accepted to **NAACL 2025**.
+- *2024.12*: &nbsp;🎉 Our study on *pre-trained code model selection for reuse* was accepted to **SANER 2025**.
+- *2024.03*: &nbsp;🎉 Our research on *counterfactual reasoning for GNN-based vulnerability detection* was accepted to **ISSTA 2024**.
+-->
 
-## Debug Locally
+### 📝 Selected Publications
 
-1. Clone your REPO to local using `git clone`.
-1. Install Jekyll building environment, including `Ruby`, `RubyGems`, `GCC` and `Make` following [the installation guide](https://jekyllrb.com/docs/installation/#requirements).
-1. Run `bash run_server.sh` to start Jekyll livereload server.
-1. Open http://127.0.0.1:4000 in your browser.
-1. If you change the source code of the website, the livereload server will automatically refresh.
-1. When you finish the modification of your homepage, `commit` your changings and `push` to your remote REPO using `git` command.
+My full paper list is shown on [my personal homepage](https://zhaoyang-chu.github.io). \* indicates equal contribution; † indicates the corresponding author.
 
-# Acknowledges
+- **Preprint**, [**TerminalWorld: Benchmarking Agents on Real-World Terminal Tasks**](https://arxiv.org/abs/2605.22535), **Zhaoyang Chu**, Jiarui Hu\*, Xingyu Jiang\*, Pengyu Zou\*, Han Li, Chao Peng, Peter O'Hearn, Earl T. Barr, Mark Harman, Federica Sarro, He Ye†.
+- **ICSE 2026**, [**Scrub It Out! Erasing Sensitive Memorization in Code Language Models via Machine Unlearning**](https://arxiv.org/abs/2509.13755), **Zhaoyang Chu**, Yao Wan†, Zhikun Zhang, Di Wang, Zhou Yang, Hongyu Zhang, Pan Zhou, Xuanhua Shi, Hai Jin, David Lo.
+- **ICML 2025**, [**CODESYNC: Synchronizing Large Language Models with Dynamic Code Evolution at Scale**](https://arxiv.org/abs/2502.16645), Chenlong Wang\*, **Zhaoyang Chu**\*, Zhengxiang Cheng\*, Xuyi Yang, Kaiyue Qiu, Yao Wan†, Zhou Zhao, Xuanhua Shi, Dongping Chen.
+- **ISSTA 2024**, [**Graph Neural Networks for Vulnerability Detection: A Counterfactual Explanation**](https://arxiv.org/abs/2404.15687), **Zhaoyang Chu**, Yao Wan†, Qian Li, Yang Wu, Hongyu Zhang, Yulei Sui, Guandong Xu, Hai Jin.
+<!--
+- **Information Sciences 2022**, **[Hierarchical Graph Representation Learning for the Prediction of Drug-Target Binding Affinity](https://www.sciencedirect.com/science/article/abs/pii/S0020025522010908)**, **Zhaoyang Chu**, Feng Huang, Haitao Fu, Yuan Quan, Xionghui Zhou, Shichao Liu, Wen Zhang\*.
+-->
 
-- AcadHomepage incorporates Font Awesome, which is distributed under the terms of the SIL OFL 1.1 and MIT License.
-- AcadHomepage is influenced by the github repo [mmistakes/minimal-mistakes](https://github.com/mmistakes/minimal-mistakes), which is distributed under the MIT License.
-- AcadHomepage is influenced by the github repo [academicpages/academicpages.github.io](https://github.com/academicpages/academicpages.github.io), which is distributed under the MIT License.
+<!--
+**Zhaoyang-Chu/Zhaoyang-Chu** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+
+Here are some ideas to get you started:
+
+- 🔭 I'm currently working on ...
+- 🌱 I'm currently learning ...
+- 👯 I'm looking to collaborate on ...
+- 🤔 I'm looking for help with ...
+- 💬 Ask me about ...
+- 📫 How to reach me: ...
+- 😄 Pronouns: ...
+- ⚡ Fun fact: ...
+-->

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -31,7 +31,7 @@ My academic journey has also been enriched by collaborations with [**Prof. Lingm
 I am also a co-founder of [**EuniAI**](https://euni.ai/), where we are building [**Prometheus**](https://github.com/EuniAI/Prometheus) — an open-source AI agent designed to push the boundaries of automated software development.
 -->
 
-> My research interests lie at the intersection of software engineering and artificial intelligence, with an emphasis on **reliable and safe coding agents** for real-world software engineering workflows.
+> My research interests lie at the intersection of software engineering and artificial intelligence, with an emphasis on **safe and reliable coding agents** for real-world software engineering workflows.
 I have published 10+ papers <a href="https://scholar.google.com/citations?user=HYu3DyEAAAAJ"><img src="https://img.shields.io/endpoint?url={{ url }}&logo=googlescholar&logoColor=white&style=for-the-badge&color=4285F4" alt="Citations" style="vertical-align:middle;height:24px!important;width:auto"></a> at top-tier international SE and AI conferences such as ICSE, FSE, ISSTA, ACL, EMNLP, ICML, and NAACL.
 For more details about my academic background, please see my [**CV**](../assets/ZhaoyangChu_CV.pdf).
 
@@ -49,6 +49,8 @@ For more details about my academic background, please see my [**CV**](../assets/
 
 # 🔥 News
 
+- *2025.06*: &nbsp;🎙️ TerminalWorld was featured on [**Last Week in AI**](https://lastweekin.ai/p/lwiai-podcast-246-gemini-35-omni) (ep. #246), a newsletter and podcast with 181k+ listeners.
+- *2025.05*: &nbsp;🤗 TerminalWorld dataset exceeded **5,000 downloads** on HuggingFace!
 - *2026.04*: &nbsp;🎉 Our two post-training papers on *code execution reasoning* and *structure-aware code understanding* was accepted to **ACL 2026**.
 - *2026.03*: &nbsp;🎉 Our paper on *LLM hallucination mitigation in code summarization* was accepted to **FSE 2026**.
 - *2025.08*: &nbsp;🎉 Our work on *efficient reasoning for R1-style LLMs* was accepted to **EMNLP 2025**.


### PR DESCRIPTION
## What

Brings the GitHub profile README in line with the current homepage (`_pages/about.md`) and adds two News items.

### `README.md` — rewrite as a condensed mirror of `about.md`
- Research blurb updated to **"safe and reliable coding agents for real-world software engineering workflows"**.
- **Selected Publications** refreshed: added flagship **TerminalWorld** (first-author preprint); aligned contribution markers (`*` = equal, `†` = corresponding) and added arXiv links to match the homepage.
- **News** block refreshed to the homepage's current list (Last Week in AI, 5,000 HF downloads, ACL/FSE 2026, EMNLP 2025, …); kept commented, matching the pasted profile layout.
- Contact line now shows **UCL + gmail** like the homepage.
- Commented out the **Rio / ICSE 2026 banner** to match its parked (commented) state in `about.md` — it was stale/visible before.
- Fixed connect-line punctuation: em-dash → comma, to match `about.md`.

### `_pages/about.md`
- Added two News lines: **TerminalWorld featured on Last Week in AI** (ep. #246) and **TerminalWorld dataset exceeded 5,000 HuggingFace downloads**.
- Minor research-blurb wording tweak ("reliable and safe" → "safe and reliable").

## Why

The profile README was still the old AcadHomepage template content with three stale publications and outdated News — fully out of sync with the live homepage. This makes the README a faithful condensed mirror so the two stay consistent.

## Note for reviewer
The README here is the source of truth that gets pasted into the separate `Zhaoyang-Chu/Zhaoyang-Chu` profile repo after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)